### PR TITLE
bugFix: setVersion argument type was unsupported in new react-native versions

### DIFF
--- a/ios/YMChatReactNative.m
+++ b/ios/YMChatReactNative.m
@@ -117,9 +117,9 @@ RCT_EXPORT_METHOD(useLiteVersion:(BOOL) shouldUseLiteVersion) {
     YMChat.shared.config.useLiteVersion = shouldUseLiteVersion;
 }
 
-RCT_EXPORT_METHOD(setVersion:(NSInteger *) version) {
+RCT_EXPORT_METHOD(setVersion:(NSNumber *) version) {
     assert(YMChat.shared.config != nil);
-    YMChat.shared.config.version = version;
+    YMChat.shared.config.version = [version integerValue];
 }
 
 RCT_EXPORT_METHOD(setCustomLoaderURL:(NSString *) url) {


### PR DESCRIPTION
- `NSInteger` are now not supported in newer react-native versions.
- Updated `setVersion` method argument to use `NSNumber` (not `NSInteger`) directly, and then extract the integer using `[version integerValue]`.