### PR TITLE
release/v3.0.0: major version bump for New Architecture support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,35 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [3.0.0]
+
+### Added
+
+- React Native New Architecture (TurboModule) support.
+- Example app for testing the New Architecture.
+
+### Changed
+
+- **BREAKING:** Migrated the YMChat module to codegen and updated dependencies.
+- iOS: use the TurboModule name and dispatch UI calls on the main thread.
+- Example iOS: CocoaPods, scheme, and App fixes.
+
+## [2.22.0]
+
+- Upgrade to compile/target SDK 35.
+
+## [2.21.2]
+
+- Bug fix: `setVersion` argument type was unsupported in newer React Native versions (#106).
+
+## [2.21.1]
+
+- Maintenance release.
+
+## [2.21.0]
+
+- Enhancement: emit error event on bot load failure (#101).

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -27,7 +27,7 @@
       }
     },
     "..": {
-      "version": "2.22.0",
+      "version": "3.0.0",
       "license": "MIT",
       "peerDependencies": {
         "react-native": ">=0.68.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ymchat-react-native",
-  "version": "2.22.0",
+  "version": "3.0.0",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## What changed

- Bump package version `2.22.0` → `3.0.0` ([package.json](package.json))
- Update the local package reference in `example/package-lock.json` to `3.0.0`
- Add `CHANGELOG.md` with a `3.0.0` entry and backfilled recent releases

## Why

This release ships React Native **New Architecture (TurboModule)** support and migrates the YMChat module to codegen. The codegen migration is a breaking change for consumers, which warrants a major version bump per semver.

## Notes for reviewers

- The `.podspec` reads its version from `package['version']`, so it picks up `3.0.0` automatically — no manual edit needed.
- `example/ios/Pods/Local Podspecs/ymchat-react-native.podspec.json` still shows `2.22.0`, but it's a generated CocoaPods artifact that refreshes on the next `pod install`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)