### PR TITLE
chore: exclude example app from npm package via files whitelist

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,20 @@
   "version": "3.0.0",
   "description": "",
   "main": "index.js",
+  "files": [
+    "index.js",
+    "src",
+    "android",
+    "ios",
+    "react-native.config.js",
+    "ymchat-react-native.podspec",
+    "README.md",
+    "CHANGELOG.md",
+    "!android/build",
+    "!android/.gradle",
+    "!android/.settings",
+    "!**/.DS_Store"
+  ],
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
## What changed

Added a `files` whitelist to [package.json](package.json) so the published npm tarball ships only the SDK source.

## Why

There was no `files` field or `.npmignore`, so `npm publish` packed the entire repo — **294 files / 25.6 MB unpacked** — including the full `example/` app and Android build artifacts (`android/build`, `.gradle`, `.settings`, `.cxx`, CMake caches).

With the whitelist, the package is now **17 files / 61.2 kB unpacked**, containing only what consumers need:

- `index.js`, `src/`
- `android/` (source + `build.gradle`, with `build`/`.gradle`/`.settings` excluded)
- `ios/`
- `react-native.config.js`, `ymchat-react-native.podspec`
- `README.md`, `CHANGELOG.md`

## Notes for reviewers

- Verified with `npm pack --dry-run`: no `example/` files and no `android/build` artifacts in the tarball.
- `v3.0.0` is already published; this fix will take effect in the next release (e.g. a `3.0.1` patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)