### PR TITLE
release/v3.0.1: patch bump for npm packaging fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.1]
+
+### Fixed
+
+- Added a `files` whitelist to `package.json` so the published npm package ships only the SDK source, excluding the example app and Android build artifacts.
+
 ## [3.0.0]
 
 ### Added

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -27,7 +27,7 @@
       }
     },
     "..": {
-      "version": "3.0.0",
+      "version": "3.0.1",
       "license": "MIT",
       "peerDependencies": {
         "react-native": ">=0.68.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ymchat-react-native",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "",
   "main": "index.js",
   "files": [


### PR DESCRIPTION
## What changed

- Bump package version `3.0.0` → `3.0.1` ([package.json](package.json))
- Add a `3.0.1` entry to `CHANGELOG.md`
- Update the local package reference in `example/package-lock.json`

## Why

A patch release to ship the npm packaging fix: a `files` whitelist now excludes the example app and Android build artifacts from the published tarball (294 files / 25.6 MB → 17 files / 61.2 kB). That fix merged into `development` but wasn't yet released, so `3.0.1` makes it available on npm.

## Notes for reviewers

- The `.podspec` reads its version from `package['version']`, so it picks up `3.0.1` automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)