### PR TITLE
Bump native SDK deps for WebView security fix (v3.0.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.2]
+
+### Security
+
+- Upgraded native SDKs to pick up a WebView URL-handling fix — Android YMChatbot-Android v3.3.1, iOS YMChat 2.2.1. No JS/bridge API changes.
+
 ## [3.0.1]
 
 ### Fixed

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -46,5 +46,5 @@ repositories {
 
 dependencies {
     compileOnly("com.facebook.react:react-android")
-    implementation 'com.github.yellowmessenger:YMChatbot-Android:v2.22.0'
+    implementation 'com.github.yellowmessenger:YMChatbot-Android:v3.3.1'
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ymchat-react-native",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "",
   "main": "index.js",
   "files": [

--- a/ymchat-react-native.podspec
+++ b/ymchat-react-native.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.swift_version = "5.0"
 
-  s.dependency "YMChat", "~> 1.24.0"
+  s.dependency "YMChat", "~> 2.2.1"
 
   # YMChat is a Swift pod. Its Objective-C compatibility header is generated at build time
   # in the pod's configuration build directory. Adding this path lets us use a plain


### PR DESCRIPTION
## Summary
- Bumps the Android dependency to `com.github.yellowmessenger:YMChatbot-Android:v3.3.1` in `android/build.gradle` (was `v2.22.0`).
- Bumps the iOS dependency to `YMChat ~> 2.2.1` in `ymchat-react-native.podspec` (was `~> 1.24.0`).
- Bumps the package version to `3.0.2` and adds a changelog entry.
- No bridge/JS API changes.

## Why
Both native SDKs shipped a WebView URL-handling security fix (tracked as ISS-15626, originating from a validated bug bounty report on the Android SDK): a JS-bridge method that loaded arbitrary URLs with no scheme check, and a WebView navigation policy that could load links in-WebView instead of externally / accept non-http(s) navigations. Fixed in:
- Android: yellowmessenger/YMChatbot-Android#129 (released as `v3.3.1`)
- iOS: yellowmessenger/YMChatbot-iOS#84 (released as `2.2.1`, published to CocoaPods trunk)

## Compatibility check
This is a larger version jump than usual (Android v2.22.0 → v3.3.1, iOS 1.24.0 → 2.2.1), so I verified the entire native API surface this package's bridge code calls, on both architectures:
- **Android** (`YMChatModule`/`YMChatService`): `YMChat`, `YMConfig` (incl. `shouldOpenLinkExternally`), `YMTheme` (incl. `linkColor`), `YMEventModel`, `YellowCallback`/`YellowDataCallback` — all present with identical signatures in `v3.3.1`.
- **iOS** (`YMChatReactNative.mm`, both the New Architecture and old-architecture implementations): every selector (`startChatbotWithAnimated:error:completion:`, `reloadBotAndReturnError:`, `revalidateTokenWithToken:refreshSession:error:`, `sendEventToBotWithEvent:error:`, `unlinkDeviceTokenWithBotId:apiKey:deviceToken:success:failure:`, `registerDeviceWithApiKey:ymConfig:success:failure:`, `getUnreadMessagesCountWithYmConfig:success:failure:`) and property (`shouldOpenLinkExternally`, `theme.linkColor`, etc.) was cross-checked against the actual compiled `YMChat-Swift.h` generated from a real `2.2.1` build — not just source inspection. No mismatches found; no bridge source changes were needed.
- `1.24.0` (the previous iOS pin) is a direct ancestor of `2.2.1` on the same linear history (no divergent branch), so this is a straight-line upgrade.

## ⚠️ Note for reviewer
`pod spec lint` against this branch currently fails with "could not find compatible versions for YMChat (~> 2.2.1)" — this is CocoaPods CDN propagation lag for the just-published `2.2.1` pod (`pod trunk push` warns it can take up to ~10 minutes; may be worth re-running the lint before merging to confirm it's cleared). `YMChat 2.2.1` is confirmed live via the trunk API (`https://trunk.cocoapods.org/api/v1/pods/YMChat`).

## Test plan
- [ ] Re-run `pod spec lint ymchat-react-native.podspec` once CDN propagation clears, confirm it passes.
- [ ] `pod install` in `example/ios` and build the example app (both old and new architecture, if the example supports toggling).
- [ ] Build the example Android app against the new dependency.
- [ ] Smoke-test `setOpenLinkExternally` / tapping a chat link on both platforms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)