### PR TITLE
Bump Android SDK for popup WebView security fix (v3.0.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.3]
+
+### Security
+
+- Upgraded native Android SDK to YMChatbot-Android v3.3.2, closing a residual WebView popup (`window.open()`) URL-scheme gap left over from the v3.3.1 fix. No JS/bridge API changes. iOS dependency unchanged.
+
 ## [3.0.2]
 
 ### Security

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -46,5 +46,5 @@ repositories {
 
 dependencies {
     compileOnly("com.facebook.react:react-android")
-    implementation 'com.github.yellowmessenger:YMChatbot-Android:v3.3.1'
+    implementation 'com.github.yellowmessenger:YMChatbot-Android:v3.3.2'
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ymchat-react-native",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "",
   "main": "index.js",
   "files": [


### PR DESCRIPTION
## Summary
- Bumps the Android dependency to `com.github.yellowmessenger:YMChatbot-Android:v3.3.2` in `android/build.gradle` (was `v3.3.1`).
- Bumps the package version to `3.0.3` (the podspec version tracks `package.json` automatically) and adds a changelog entry.
- No bridge/JS API changes. iOS dependency is unchanged (see below).

## Why
`v3.3.2` closes a residual gap from the original `v3.3.1` fix (ISS-15626): the popup WebView opened via `window.open()`/`target=_blank` (`onCreateWindow`) is a separate WebView instance that didn't inherit the main WebView's http(s)-only scheme allowlist or `allowFileAccess = false` setting, so `javascript:`/`file:` URLs could still load there. Fixed in yellowmessenger/YMChatbot-Android#130, released as `v3.3.2`.

iOS is not affected by this follow-up — its `window.open()` handler (`createWebViewWith` in `WKUIDelegate`) never creates a real `WKWebView` (always returns `nil`), so there's no equivalent popup-rendering surface there. No iOS podspec change needed.

## Test plan
- [ ] Android build resolves the new dependency and links cleanly.
- [ ] Smoke-test a chat popup link on Android via the example app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)