### PR TITLE
Bump native SDKs for Voice Mode screen-wake fix (3.1.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.0]
+
+### Added
+
+- Upgraded native SDKs to pick up automatic screen-awake handling during Voice Mode — Android YMChatbot-Android v3.4.0, iOS YMChat 2.3.0. The screen now stays on for the duration of an active voice conversation and returns to normal on call end; entirely internal to the native SDKs, no JS/bridge API changes.
+
 ## [3.0.3]
 
 ### Security

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -46,5 +46,5 @@ repositories {
 
 dependencies {
     compileOnly("com.facebook.react:react-android")
-    implementation 'com.github.yellowmessenger:YMChatbot-Android:v3.3.2'
+    implementation 'com.github.yellowmessenger:YMChatbot-Android:v3.4.0'
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ymchat-react-native",
-  "version": "3.0.3",
+  "version": "3.1.0",
   "description": "",
   "main": "index.js",
   "files": [

--- a/ymchat-react-native.podspec
+++ b/ymchat-react-native.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.swift_version = "5.0"
 
-  s.dependency "YMChat", "~> 2.2.1"
+  s.dependency "YMChat", "~> 2.3.0"
 
   # YMChat is a Swift pod. Its Objective-C compatibility header is generated at build time
   # in the pod's configuration build directory. Adding this path lets us use a plain


### PR DESCRIPTION
## Summary
- Bumps the pinned native SDK deps: Android `YMChatbot-Android` v3.3.2 → v3.4.0, iOS `YMChat` ~> 2.2.1 → ~> 2.3.0.
- Both releases add automatic screen-awake handling during Voice Mode (screen stays on for the duration of an active voice call, restores on end) — entirely internal to the native SDKs, no JS/bridge API changes here.

## Test plan
- [ ] `pod install` in `example/ios` and confirm `YMChat 2.3.0` resolves
- [ ] Gradle sync in `example/android` and confirm `YMChatbot-Android:v3.4.0` resolves
- [ ] Manual: start Voice Mode via the example app, confirm the screen doesn't lock during the call